### PR TITLE
intorduce emotion

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
   'parserOptions': {
     'project': './tsconfig.json'
   },
-  plugins: ['@typescript-eslint', 'react-hooks'],
+  plugins: ['@typescript-eslint', 'react-hooks', 'emotion'],
   rules: {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
@@ -26,6 +26,7 @@ module.exports = {
       'ignoreRestSiblings': false,
       'argsIgnorePattern': '^_',
     }],
+    'emotion/syntax-preference': [2, "string"],
     'import/no-extraneous-dependencies': [
       'error',
       {

--- a/babel.config.js
+++ b/babel.config.js
@@ -12,13 +12,16 @@ module.exports = {
     '@babel/react',
   ],
   plugins: [
+    'emotion',
     '@babel/proposal-class-properties',
     '@babel/proposal-object-rest-spread',
     'ts-optchain',
   ],
   env: {
     development: {
-      plugins: ['react-hot-loader/babel'],
+      plugins: [
+        'react-hot-loader/babel',
+      ],
     },
   },
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "storybook": "start-storybook -p 6006"
   },
   "dependencies": {
+    "@emotion/core": "10.0.16",
+    "@emotion/styled": "10.0.15",
     "antd": "^3.22.0",
     "core-js": "^3.2.1",
     "react": "^16.9.0",
@@ -49,6 +51,7 @@
     "@typescript-eslint/eslint-plugin": "2.0.0",
     "@typescript-eslint/parser": "2.0.0",
     "babel-loader": "8.0.6",
+    "babel-plugin-emotion": "10.0.16",
     "babel-plugin-syntax-dynamic-import": "6.18.0",
     "babel-plugin-ts-optchain": "1.1.5",
     "clean-webpack-plugin": "3.0.0",
@@ -56,6 +59,7 @@
     "eslint": "6.2.2",
     "eslint-config-airbnb": "18.0.1",
     "eslint-config-prettier": "6.1.0",
+    "eslint-plugin-emotion": "10.0.14",
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jsx-a11y": "6.2.3",
     "eslint-plugin-prettier": "3.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,31 +1,41 @@
 import React from 'react'
 import { Card, version, Icon, Button } from 'antd'
+import styled from '@emotion/styled'
 import { hot } from 'react-hot-loader/root'
 
 import 'antd/dist/antd.css'
 
+const StyledCard = styled(Card)`
+  width: 300px;
+  && {
+    margin: 20px 0;
+  }
+`
+
+const StyledLargeCard = styled(Card)`
+  width: 600px;
+`
+
 const SampleCards = () => {
   return (
     <div>
-      <Card
+      <StyledCard
         title="Default size card"
         // eslint-disable-next-line jsx-a11y/anchor-is-valid
         extra={<a href="#">More</a>}
-        style={{ width: 300, margin: '20px' }}
       >
         <p>Card content</p>
         <p>Card content</p>
         <p>Card content</p>
-      </Card>
-      <Card
+      </StyledCard>
+      <StyledLargeCard
         size="default"
         title="Large size card"
         // eslint-disable-next-line jsx-a11y/anchor-is-valid
         extra={<a href="#">More</a>}
-        style={{ width: 600, margin: '20px' }}
       >
         <ButtonSize />
-      </Card>
+      </StyledLargeCard>
     </div>
   )
 }
@@ -74,21 +84,23 @@ const ButtonSize: React.FC<Props> = ({ size = 'small' }) => {
   )
 }
 
+const Wrapper = styled('div')`
+  padding: 16px;
+`
+const StyledButton = styled(Button)`
+  margin: 16px 0;
+`
+
 const BaseApp: React.FC = () => {
   return (
-    <div>
+    <Wrapper>
       <div className="App">
         <h1>Please fork this codesandbox to reproduce your issue.</h1>
         <div>Current antd version: {version}</div>
-        <div style={{ marginTop: '16px' }}>
-          <Button type="primary">Example buttons</Button>
-        </div>
-
-        <div style={{ padding: '10px' }} />
-
+        <StyledButton type="primary">Example buttons</StyledButton>
         <SampleCards />
       </div>
-    </div>
+    </Wrapper>
   )
 }
 

--- a/src/components/atoms/MyCard/index.tsx
+++ b/src/components/atoms/MyCard/index.tsx
@@ -1,19 +1,28 @@
 import * as React from 'react'
-import { Card as AntCard } from 'antd'
+import { Card } from 'antd'
+import { CardProps } from 'antd/lib/card'
+import styled from '@emotion/styled'
 
 export type Props = {
   isLoading: boolean
   contents: string
 }
 
+type StyledCardProps = CardProps & {
+  bgColor?: string
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const StyledCard = styled<React.FC<StyledCardProps>>(Card as any)`
+  width: 500px;
+  margin: 10px;
+  background: ${props => props.bgColor};
+`
+
 const MyCard: React.FC<Props> = ({ isLoading, contents }) => (
-  <AntCard
-    loading={isLoading}
-    title="title"
-    style={{ width: 500, margin: '10px' }}
-  >
+  <StyledCard loading={isLoading} title="title">
     {contents}
-  </AntCard>
+  </StyledCard>
 )
 
 export default MyCard

--- a/yarn.lock
+++ b/yarn.lock
@@ -873,7 +873,7 @@
     "@emotion/utils" "0.11.2"
     "@emotion/weak-memoize" "0.2.3"
 
-"@emotion/core@^10.0.9":
+"@emotion/core@10.0.16", "@emotion/core@^10.0.9":
   version "10.0.16"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.16.tgz#e43630b65c84e31e81f34db3286eab584b08cfaa"
   integrity sha512-whbiiA7FfPreBY4BqWky2qRfAZvq+4dKQ1WNJuiYQwPCNmb0pEYDgNheSbZoNKtGTtfPaM28hBbZAKWD5EZXmQ==
@@ -957,7 +957,7 @@
     "@emotion/serialize" "^0.11.9"
     "@emotion/utils" "0.11.2"
 
-"@emotion/styled@^10.0.7":
+"@emotion/styled@10.0.15", "@emotion/styled@^10.0.7":
   version "10.0.15"
   resolved "https://registry.yarnpkg.com/@emotion/styled/-/styled-10.0.15.tgz#bc99b968bdbf491db7bc474bb90c8fcdbe0f2f87"
   integrity sha512-vIKDo/hG741PNRpMnrJ6R8NnnjYfOBw3d6cb3yNckpjcp0NNq3ugE8/EjcYBU1Ke44nx2p00h5uzE396xOLJIg==
@@ -2443,7 +2443,7 @@ babel-plugin-dynamic-import-node@2.3.0, babel-plugin-dynamic-import-node@^2.3.0:
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-emotion@^10.0.14, babel-plugin-emotion@^10.0.15, babel-plugin-emotion@^10.0.9:
+babel-plugin-emotion@10.0.16, babel-plugin-emotion@^10.0.14, babel-plugin-emotion@^10.0.15, babel-plugin-emotion@^10.0.9:
   version "10.0.16"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.16.tgz#cb306798058b102a634ca80e69b012caa345bb09"
   integrity sha512-a01Xrourr/VRpw4KicX9drDwfVGHmw8HmlQk++N4fv0j73EfHKWC1Ah4Vu8s1cTGVvTiwum+UhVpJenV8j03FQ==
@@ -4432,6 +4432,11 @@ eslint-module-utils@^2.4.0:
   dependencies:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
+
+eslint-plugin-emotion@10.0.14:
+  version "10.0.14"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-emotion/-/eslint-plugin-emotion-10.0.14.tgz#c643ff2f34f85ae77a65b2056915e939cf7e8129"
+  integrity sha512-kI0hTPA5oo7MAc2YcdF1JcT36TZ1Ci0S5sbA9aojZ3leEPyCH34YBB76/8NQ3/9gybqrekIEuEhr8MP6JZf95Q==
 
 eslint-plugin-import@2.18.2:
   version "2.18.2"


### PR DESCRIPTION
## TL;DR

- emotionを導入
  - emotion/core, emotion/styled のみ
- バベるときにいい感じに最適化してくれるらしいので [babel-plugin](https://emotion.sh/docs/babel-plugin-emotion) を追加
- テンプレートリテラルで縛りプレイしたいので [eslint-plugin](https://emotion.sh/docs/eslint-plugin-emotion)を追加

## Check list

- [x] CSS in JS できる